### PR TITLE
Fix DNS domain network setting

### DIFF
--- a/rc.local
+++ b/rc.local
@@ -46,7 +46,7 @@ Name=e*
 Address=${IP_ADDRESS}/${NETMASK}
 Gateway=${GATEWAY}
 DNS=${DNS_SERVER}
-Domain=${DNS_DOMAIN}
+Domains=${DNS_DOMAIN}
 __CUSTOMIZE_PHOTON__
 
     hostnamectl set-hostname ${HOSTNAME}


### PR DESCRIPTION
The correct option to set DNS domains is `Domains`. 

Source: https://man.archlinux.org/man/systemd.network.5#%5BNETWORK%5D_SECTION_OPTIONS